### PR TITLE
B4: filter pin events by location, add locations constants

### DIFF
--- a/STATUS_REPORT.md
+++ b/STATUS_REPORT.md
@@ -16,7 +16,7 @@ behind**, and Brandon + Matt are on the critical path for everyone else.
 | Teammate | Track | On track? | Done | Partial | Not done | Notes |
 |----------|-------|-----------|------|---------|----------|-------|
 | Bryan    | C — UI / map / iOS  | ✅ on-track | 4 | 1 | 0 (1 unverified) | C1 partial (low-res asset), C5 awaiting walkthrough |
-| Talan    | B — event display   | ⚠️ lagging | 3 | 0 | 3 | B5 hard-blocked on Brandon (A4); B4 hard-blocked on Matt (D3) |
+| Talan    | B — event display   | ⚠️ lagging | 4 | 0 | 2 | B5 hard-blocked on Brandon (A4); B6 unblocked |
 | Brandon  | A — backend         | 🚫 critical-path blocker | 0 | 0 | 6 | branch only has `.env.example` + `.gitignore`; no Firebase code |
 | Matt     | D — pins / integration | 🚫 critical-path blocker | 0 | 0 | 5 | branch `feature/matt/pins-integration` does not exist on origin |
 
@@ -60,11 +60,11 @@ behind**, and Brandon + Matt are on the critical path for everyone else.
 | B1 `app/utils/mockEvents.ts` | ✅ Done | `app/utils/mockEvents.tsx` on master |
 | B2 `EventList.tsx` | ✅ Done | `app/components/EventList.tsx` on master |
 | B3 EventList wired into `sideMenu.tsx` | ✅ Done | `sideMenu.tsx` imports EventList from `./components/EventList`; PLACEHOLDER_EVENTS array and SideMenuEntry component removed; ScrollView replaced with `<EventList events={MOCK_EVENTS} loading={false} />`; loading spinner and empty state delegated to EventList props |
-| B4 `pinDetails.tsx` filters events | 🚫 NotDone | only fires a static `Alert.alert('Gym Club…')`; no `events.filter`, no "See All" link |
+| B4 `pinDetails.tsx` filters events | ✅ Done | accepts `location` prop; filters `MOCK_EVENTS` by location; shows `EventList` in a modal; `app/constants/locations.ts` added |
 | B5 swap mock for `getActiveEvents` | 🚫 NotDone (blocked by A4) | `getActiveEvents` not referenced anywhere |
 | B6 tests | 🚫 NotDone | no test files |
 
-**What's blocking him:** B5 is hard-blocked on Brandon's A4. B4 is hard-blocked on Matt's D3 (`locations.ts` shared map). B1, B3, B6 are unblocked and can be done today.
+**What's blocking him:** B5 is hard-blocked on Brandon's A4. B6 (tests) is unblocked — jest setup + render/filter tests can be written now against mock data.
 
 **Outreach scaffolded:** 5 per-task issues + 1 tracking issue (see `.agent/outreach/07-11`, `20`).
 

--- a/app/constants/locations.ts
+++ b/app/constants/locations.ts
@@ -1,0 +1,9 @@
+export const LOCATIONS = {
+  TONY_GWYNN_STADIUM: "Tony Gwynn Stadium",
+  STORM_HALL_WEST_111: "Storm Hall West 111",
+  ENGINEERING_BUILDING_250: "Engineering Building 250",
+  STUDENT_UNION_302: "Student Union 302",
+  AZTEC_STUDENT_UNION: "Conrad Prebys Aztec Student Union",
+} as const;
+
+export type LocationName = (typeof LOCATIONS)[keyof typeof LOCATIONS];

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,10 +2,11 @@
 // map markers (pins) overlaid on top. Tapping a pin opens a modal popup with
 // event details. Also renders the AboutScreen banner at the bottom.
 import { useState } from "react";
-import { Image, Modal, Platform, Pressable, ScrollView, Text, useWindowDimensions, View } from "react-native";
+import { Platform, Pressable, ScrollView, Text, useWindowDimensions, View } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import AboutScreen from "./aboutScreen";
 import AddEventModal from "./components/AddEventModal";
+import { LOCATIONS } from "./constants/locations";
 import { colors, radius, spacing, tap, typography } from "./constants/theme";
 import ImageC from "./image";
 import PinDetails from "./pinDetails";
@@ -22,7 +23,6 @@ export default function Index() {
   // under iPhone's status bar or home indicator in portrait.
   const mapHeight = Math.max(height - topBarHeight - bottomBarHeight - insets.top - insets.bottom, 0);
 
-  const [modalVis, setModalVis] = useState(false);
   const [addEventVis, setAddEventVis] = useState(false);
 
   return (
@@ -74,9 +74,10 @@ export default function Index() {
           contentFit="contain"
         />
 
-        {/* PinDetails marker — tapping shows an alert with placeholder text */}
+        {/* Storm Hall West pin — shows Aztec Game Lab events */}
         <PinDetails
           source={require("../assets/images/marker.png")}
+          location={LOCATIONS.STORM_HALL_WEST_111}
           style={{
             position: "absolute",
             top: mapHeight * 0.42,
@@ -87,83 +88,19 @@ export default function Index() {
           }}
         />
 
-        {/* Second marker — tapping opens the event details modal */}
-        <Pressable
-          onPress={() => setModalVis(true)}
-          style={{ position: "absolute", top: mapHeight * 0.4, left: mapWidth * 0.5, width: mapWidth * 0.04, height: mapHeight * 0.065, zIndex: 9999 }}
-        >
-          <Image
-            source={require("../assets/images/marker.png")}
-            style={{
-              width: "100%",
-              height: "100%",
-            }}
-          />
-        </Pressable>
-
-        {/* Modal popup shown when a marker is tapped, displays event info.
-            Backdrop tap and Android hardware back both dismiss. */}
-        <Modal
-          visible={modalVis}
-          animationType="fade"
-          transparent={true}
-          onRequestClose={() => setModalVis(false)}
-          supportedOrientations={[
-            "portrait",
-            "portrait-upside-down",
-            "landscape",
-            "landscape-left",
-            "landscape-right",
-          ]}
-        >
-          <Pressable
-            onPress={() => setModalVis(false)}
-            style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.overlay }}
-            accessibilityLabel="Close event details"
-          >
-            <Pressable
-              // Inner pressable swallows taps so backdrop dismiss only fires
-              // outside the card body.
-              onPress={(e) => e.stopPropagation?.()}
-              style={{
-                minWidth: Math.min(width * 0.7, 320),
-                maxWidth: 360,
-                backgroundColor: colors.white,
-                borderRadius: radius.lg,
-                paddingVertical: spacing.lg,
-                paddingHorizontal: spacing.lg,
-              }}
-            >
-              {/* Close X — visible affordance, ≥44pt hit area, top-right. */}
-              <Pressable
-                onPress={() => setModalVis(false)}
-                accessibilityRole="button"
-                accessibilityLabel="Close dialog"
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                style={{
-                  position: "absolute",
-                  top: spacing.sm,
-                  right: spacing.sm,
-                  width: tap.minSize,
-                  height: tap.minSize,
-                  alignItems: "center",
-                  justifyContent: "center",
-                  zIndex: 2,
-                }}
-              >
-                <Text style={{ ...typography.h3, color: colors.neutral600 }}>×</Text>
-              </Pressable>
-
-              <Text style={{ ...typography.h3, color: colors.neutral900, marginBottom: spacing.xs, marginRight: tap.minSize }}>
-                Aztec Baseball Club
-              </Text>
-              {/* TODO(dvicente4482-sys): wire to dynamic event object instead of static text */}
-              <Text style={{ ...typography.body, color: colors.neutral700 }}>
-                3:30 – 5:30 pm
-              </Text>
-            </Pressable>
-          </Pressable>
-        </Modal>
+        {/* Tony Gwynn Stadium pin — shows Aztec Baseball Club events */}
+        <PinDetails
+          source={require("../assets/images/marker.png")}
+          location={LOCATIONS.TONY_GWYNN_STADIUM}
+          style={{
+            position: "absolute",
+            top: mapHeight * 0.4,
+            left: mapWidth * 0.5,
+            width: mapWidth * 0.04,
+            height: mapHeight * 0.065,
+            zIndex: 999,
+          }}
+        />
       </View>
       </ScrollView>
 

--- a/app/pinDetails.tsx
+++ b/app/pinDetails.tsx
@@ -1,51 +1,105 @@
-// PinDetails renders a single map marker pin as a tappable image.
-// On press, it shows an alert (native on mobile, browser alert on web)
-// with placeholder event info. The `pressed` state tracks whether the
-// pin has been tapped at least once.
+import { useState } from 'react';
 import {
-  Alert,
   ImageSourcePropType,
-  Platform,
+  Modal,
+  Pressable,
   StyleProp,
   StyleSheet,
+  Text,
   TouchableOpacity,
+  useWindowDimensions,
+  View,
   ViewStyle
 } from 'react-native';
+import EventList from './components/EventList';
+import { colors, radius, spacing, tap, typography } from './constants/theme';
 import ImageC from './image';
+import { MOCK_EVENTS } from './utils/mockEvents';
 
-// Props accepted by PinDetails:
-//   source — the marker image asset
-//   style  — position/size styles applied by the parent (absolute positioning)
 type PinDetailsProps = {
   source: ImageSourcePropType;
   style: StyleProp<ViewStyle>;
+  location: string;
 };
 
-export default function PinDetails({ source, style }: PinDetailsProps) {
-  const handlePress = () => {
-    Platform.OS === 'web' ? alert('Gym Club 2-3:15pm') : Alert.alert('Gym Club 2-3:15pm');
-  };
+export default function PinDetails({ source, style, location }: PinDetailsProps) {
+  const { width } = useWindowDimensions();
+  const [modalVis, setModalVis] = useState(false);
+  const events = MOCK_EVENTS.filter(e => e.location === location);
 
   return (
-    // TouchableOpacity wraps the pin image to make it pressable.
-    // activeOpacity=0 means no visual dimming on press.
-    <TouchableOpacity
-      style={[styles.wrapper, style]}
-      onPress={handlePress}
-      activeOpacity={0.0}
-    >
-      <ImageC
-        source={source}
-        style={styles.image}
-        contentFit="contain" // scale image to fit without cropping
-      />
-    </TouchableOpacity>
+    <>
+      <TouchableOpacity
+        style={[styles.wrapper, style]}
+        onPress={() => setModalVis(true)}
+        activeOpacity={0.7}
+      >
+        <ImageC
+          source={source}
+          style={styles.image}
+          contentFit="contain"
+        />
+      </TouchableOpacity>
+
+      <Modal
+        visible={modalVis}
+        animationType="fade"
+        transparent
+        onRequestClose={() => setModalVis(false)}
+        supportedOrientations={["portrait", "portrait-upside-down", "landscape", "landscape-left", "landscape-right"]}
+      >
+        <Pressable
+          onPress={() => setModalVis(false)}
+          style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.overlay }}
+          accessibilityLabel={`Close ${location} events`}
+        >
+          <Pressable
+            onPress={(e) => e.stopPropagation?.()}
+            style={{
+              width: Math.min(width * 0.85, 360),
+              backgroundColor: colors.white,
+              borderRadius: radius.lg,
+              paddingTop: spacing.lg,
+              paddingBottom: spacing.lg,
+              paddingHorizontal: spacing.lg,
+              maxHeight: 420,
+            }}
+          >
+            <Pressable
+              onPress={() => setModalVis(false)}
+              accessibilityRole="button"
+              accessibilityLabel="Close dialog"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              style={{
+                position: "absolute",
+                top: spacing.sm,
+                right: spacing.sm,
+                width: tap.minSize,
+                height: tap.minSize,
+                alignItems: "center",
+                justifyContent: "center",
+                zIndex: 2,
+              }}
+            >
+              <Text style={{ ...typography.h3, color: colors.neutral600 }}>×</Text>
+            </Pressable>
+
+            <Text style={{ ...typography.h3, color: colors.neutral900, marginBottom: spacing.sm, marginRight: tap.minSize }}>
+              {location}
+            </Text>
+            <View style={{ flex: 0 }}>
+              <EventList events={events} loading={false} />
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   wrapper: {
-    zIndex: 999, // render above the map image
+    zIndex: 999,
   },
   image: {
     width: '100%',

--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -59,7 +59,7 @@ Branch: `feature/talan/event-display`
 - [x] **B2** `app/components/EventList.tsx` — card list sorted by time
 - [x] **B3** Wire `EventList` into `app/sideMenu.tsx`; add loading + empty
       states
-- [ ] **B4** `app/pinDetails.tsx` — filter events to the tapped pin's
+- [x] **B4** `app/pinDetails.tsx` — filter events to the tapped pin's
       location (use `app/constants/locations.ts` from D3 for exact strings)
 - [ ] **B5** Swap mock data for `getActiveEvents()` once A4 lands
 - [ ] **B6** Render and filter tests; manual run via `npx expo start`


### PR DESCRIPTION
gh pr edit --body @'
Refs #9

## What changed
- New `app/constants/locations.ts` (LOCATIONS map, covers D3 dependency)
- `app/pinDetails.tsx` rewritten: accepts `location` prop, filters MOCK_EVENTS, shows EventList in a modal instead of a static Alert
- `app/index.tsx`: both pins now use PinDetails with typed location strings; removed hardcoded modal

## Testing
Tap Storm Hall West pin → Aztec Game Lab. Tap Tony Gwynn Stadium pin → Aztec Baseball Club.

## Blocked
- B5 (live data) still waiting on Brandon A4
'@

