### PR TITLE
B4: show top-3 pin events in modal with See All button

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -24,6 +24,7 @@ export default function Index() {
   const mapHeight = Math.max(height - topBarHeight - bottomBarHeight - insets.top - insets.bottom, 0);
 
   const [addEventVis, setAddEventVis] = useState(false);
+  const [sideMenuOpen, setSideMenuOpen] = useState(false);
 
   return (
     // SafeAreaView keeps top bar below the iPhone notch/status bar and the
@@ -78,6 +79,7 @@ export default function Index() {
         <PinDetails
           source={require("../assets/images/marker.png")}
           location={LOCATIONS.STORM_HALL_WEST_111}
+          onSeeAll={() => setSideMenuOpen(true)}
           style={{
             position: "absolute",
             top: mapHeight * 0.42,
@@ -92,6 +94,7 @@ export default function Index() {
         <PinDetails
           source={require("../assets/images/marker.png")}
           location={LOCATIONS.TONY_GWYNN_STADIUM}
+          onSeeAll={() => setSideMenuOpen(true)}
           style={{
             position: "absolute",
             top: mapHeight * 0.4,
@@ -139,7 +142,11 @@ export default function Index() {
       </View>
 
       {/* Side menu (just seperated for ease of access, cleaner imo) */}
-      <SideMenu />
+      <SideMenu
+        open={sideMenuOpen}
+        onOpen={() => setSideMenuOpen(true)}
+        onClose={() => setSideMenuOpen(false)}
+      />
 
       </View>
     </SafeAreaView>

--- a/app/pinDetails.tsx
+++ b/app/pinDetails.tsx
@@ -20,12 +20,16 @@ type PinDetailsProps = {
   source: ImageSourcePropType;
   style: StyleProp<ViewStyle>;
   location: string;
+  onSeeAll: () => void;
 };
 
-export default function PinDetails({ source, style, location }: PinDetailsProps) {
+export default function PinDetails({ source, style, location, onSeeAll }: PinDetailsProps) {
   const { width } = useWindowDimensions();
   const [modalVis, setModalVis] = useState(false);
-  const events = MOCK_EVENTS.filter(e => e.location === location);
+  const events = MOCK_EVENTS
+    .filter(e => e.location === location)
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+    .slice(0, 3);
 
   return (
     <>
@@ -90,6 +94,21 @@ export default function PinDetails({ source, style, location }: PinDetailsProps)
             <View style={{ flex: 0 }}>
               <EventList events={events} loading={false} />
             </View>
+            <Pressable
+              onPress={() => { setModalVis(false); onSeeAll(); }}
+              accessibilityRole="button"
+              accessibilityLabel="See all campus events"
+              style={({ pressed }) => ({
+                marginTop: spacing.md,
+                minHeight: tap.minSize,
+                borderRadius: radius.md,
+                backgroundColor: pressed ? colors.scarletDark : colors.scarlet,
+                alignItems: "center",
+                justifyContent: "center",
+              })}
+            >
+              <Text style={{ ...typography.button, color: colors.scarletInk }}>See All</Text>
+            </Pressable>
           </Pressable>
         </Pressable>
       </Modal>

--- a/app/sideMenu.tsx
+++ b/app/sideMenu.tsx
@@ -1,12 +1,16 @@
-import { useState } from "react";
 import { Modal, Pressable, Text, useWindowDimensions, View } from "react-native";
 import EventList from "./components/EventList";
 import { colors, radius, spacing, tap, typography } from "./constants/theme";
 import { MOCK_EVENTS } from "./utils/mockEvents";
 
-export const SideMenu = function () {
+type SideMenuProps = {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+export const SideMenu = function ({ open, onOpen, onClose }: SideMenuProps) {
   const { width } = useWindowDimensions();
-  const [sideModalVis, setSideModalVis] = useState(false);
 
   const panelWidth = Math.min(Math.max(width * 0.78, 260), 360);
 
@@ -14,7 +18,7 @@ export const SideMenu = function () {
     <>
       {/* Trigger pinned top-left of the screen. ≥44pt tap target. */}
       <Pressable
-        onPress={() => setSideModalVis(true)}
+        onPress={onOpen}
         accessibilityRole="button"
         accessibilityLabel="Open events list"
         style={({ pressed }) => ({
@@ -40,14 +44,14 @@ export const SideMenu = function () {
       </Pressable>
 
       <Modal
-        visible={sideModalVis}
+        visible={open}
         animationType="slide"
         transparent
-        onRequestClose={() => setSideModalVis(false)}
+        onRequestClose={onClose}
       >
         {/* Tap outside the panel to dismiss. */}
         <Pressable
-          onPress={() => setSideModalVis(false)}
+          onPress={onClose}
           accessibilityLabel="Close events list"
           style={{ flex: 1, backgroundColor: colors.overlay, flexDirection: "row" }}
         >
@@ -70,7 +74,7 @@ export const SideMenu = function () {
             <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: spacing.lg }}>
               <Text style={{ ...typography.h2, color: colors.neutral900 }}>Events</Text>
               <Pressable
-                onPress={() => setSideModalVis(false)}
+                onPress={onClose}
                 accessibilityRole="button"
                 accessibilityLabel="Close events list"
                 hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}


### PR DESCRIPTION
## Track

- [ ] A — Brandon (backend)
- [x] B — Talan (event display)
- [ ] C — Bryan (UI / map / iOS)
- [ ] D — Matt (pins / integration)

## What changed

- Tapping a pin now shows up to 3 real events for that location, sorted by start time
- Added a "See All" button in the pin modal that closes it and opens the full side menu
- Lifted side menu open state to Index so pins can trigger it

## Linked issue(s)

Closes #84

